### PR TITLE
Add import aliases to webpack for Components and CSS.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,17 @@
 module.exports = {
-  "extends": "airbnb",
-  "plugins": [
-    "react",
-    "jsx-a11y",
-    "import"
+  'extends': 'airbnb',
+  'plugins': [
+    'react',
+    'jsx-a11y',
+    'import'
   ],
-  "rules": {
-    "react/prefer-stateless-function": "off",
+  'rules': {
+    // Allows writing components as classes
+    'react/prefer-stateless-function': 'off',
+
+    // Allows importing of unresolved modules (primary purpose here is to not lint cases
+    // where webpack is helping resolve packages from the root directory, for example)
+    'import/no-unresolved': 'off',
+    'import/no-extraneous-dependencies': 'off',
   }
 };

--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-require('../css/App.scss');
+require('CSS/App.scss');
 
 class App extends React.Component {
   render() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,9 +3,10 @@
 const path = require('path');
 
 module.exports = {
-  entry: path.resolve(__dirname, 'src/index.jsx'),
+  context: __dirname,
+  entry: path.resolve(__dirname, './src/index.jsx'),
   output: {
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, './dist'),
     filename: 'bundle.js',
     // Necessary to let webpack-dev-server connect the dist folder to index.html
     publicPath: '/dist/'
@@ -14,7 +15,11 @@ module.exports = {
   devtool: 'eval-cheap-module-source-map',
   // Allows importing of .jsx files without specifying the file suffix
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    alias: {
+      CSS: path.resolve(__dirname, './src/css'),
+      Components: path.resolve(__dirname, './src/js'),
+    },
+    extensions: ['', '.js', '.jsx'],
   },
   module: {
     preLoaders: [


### PR DESCRIPTION
Makes it easier to import Components and CSS files by removing the need for relative paths.